### PR TITLE
feature/inventory toggle keybindings

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -10,7 +10,6 @@ rules:
   no-empty-function: warn
   no-eq-null: warn
   no-floating-decimal: warn
-  no-invalid-this: warn
   no-implicit-globals: warn
   no-implicit-coercion: warn
   no-warning-comments: warn

--- a/src/components/button/index.js
+++ b/src/components/button/index.js
@@ -2,11 +2,17 @@ import React from 'react';
 
 import './styles.scss';
 
-const Button = ({ icon, title, iconStyle, style, indicator, onClick, small }) => {
+const Button = ({ icon, title, iconStyle, style, indicator, onClick, onKeyDown, small }) => {
 
   function handleClick() {
     if(typeof onClick === 'function') {
       onClick();
+    }
+  }
+
+  function handleKeyDown(event) {
+    if(typeof onKeyDown === 'function') {
+      onKeyDown(event);
     }
   }
 
@@ -16,7 +22,8 @@ const Button = ({ icon, title, iconStyle, style, indicator, onClick, small }) =>
     <button
       className={`button__container white-border ${small ? 'button__container--small' : ''}`}
       style={style || {}}
-      onClick={handleClick}>
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}>
 
       {
         icon &&

--- a/src/features/inventory/index.js
+++ b/src/features/inventory/index.js
@@ -71,14 +71,11 @@ class Inventory extends Component {
               indicator={newItemIndicator}
               onClick={this._toggleInventory}
               onKeyDown={this.handleKeyDown}
-              icon={open ?
-                'times' : 'briefcase'}
-              iconStyle={open ?
-                {fontSize: 22} : {fontSize: sideMenu ? 20 : 23}}
-              title={open ?
-                'Close' : 'Inventory'}
+              icon={open ? 'times' : 'briefcase'}
+              iconStyle={open ? {fontSize: 22} : {fontSize: sideMenu ? 20 : 23}}
+              title={open ? 'Close' : '[I]nventory'}
               style={{
-                width: open ? 135 : 195,
+                width: open ? 135 : 210,
                 transition: 'width .25s ease-out',
                 whiteSpace: 'nowrap',
                 overflow: 'hidden',

--- a/src/features/inventory/index.js
+++ b/src/features/inventory/index.js
@@ -33,6 +33,18 @@ class Inventory extends Component {
     }
   }
 
+  handleKeyDown = event => {
+    switch(event.keyCode) {
+      case 13:
+      case 32:
+        // Don't toggle the inventory visibility with any of these keys
+        // because right now, they're being used for the attack order.
+        event.preventDefault();
+        break;
+      default:
+    }
+  }
+
   _toggleInventory() {
     // We can turn off the indicator if the inventory is opened
     // If we are closing the inventory, it is okay to turn off
@@ -55,6 +67,7 @@ class Inventory extends Component {
               small={sideMenu}
               indicator={newItemIndicator}
               onClick={this._toggleInventory.bind(this)}
+              onKeyDown={this.handleKeyDown}
               icon={open ?
                 'times' : 'briefcase'}
               iconStyle={open ?

--- a/src/features/inventory/index.js
+++ b/src/features/inventory/index.js
@@ -13,6 +13,9 @@ class Inventory extends Component {
     this.state = {
       newItemIndicator: false
     };
+
+    this._toggleInventory = this._toggleInventory.bind(this);
+    this.handleKeyDown = this.handleKeyDown.bind(this);
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -33,7 +36,7 @@ class Inventory extends Component {
     }
   }
 
-  handleKeyDown = event => {
+  handleKeyDown(event) {
     switch(event.keyCode) {
       case 13:
       case 32:
@@ -66,7 +69,7 @@ class Inventory extends Component {
             <Button
               small={sideMenu}
               indicator={newItemIndicator}
-              onClick={this._toggleInventory.bind(this)}
+              onClick={this._toggleInventory}
               onKeyDown={this.handleKeyDown}
               icon={open ?
                 'times' : 'briefcase'}

--- a/src/features/inventory/index.js
+++ b/src/features/inventory/index.js
@@ -13,9 +13,6 @@ class Inventory extends Component {
     this.state = {
       newItemIndicator: false
     };
-
-    this._toggleInventory = this._toggleInventory.bind(this);
-    this.handleKeyDown = this.handleKeyDown.bind(this);
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -36,7 +33,7 @@ class Inventory extends Component {
     }
   }
 
-  handleKeyDown(event) {
+  handleKeyDown = event => {
     switch(event.keyCode) {
       case 13:
       case 32:
@@ -48,7 +45,7 @@ class Inventory extends Component {
     }
   }
 
-  _toggleInventory() {
+  _toggleInventory = () => {
     // We can turn off the indicator if the inventory is opened
     // If we are closing the inventory, it is okay to turn off
     // indicator since it should be false already

--- a/src/features/player/controls.js
+++ b/src/features/player/controls.js
@@ -17,10 +17,8 @@ const Controls = ({ isGamePaused, attackMonster, movePlayer, toggleInventory }) 
 
   const _handleKeyDown = _debounce(event => {
     // if the game is not paused by dialogs
-    if(!isGamePaused()) handleKeyDown(event);
-
     // toggle inventory visibility regardless of whether it is paused by dialogs
-    handleInventoryVisibilityKeyDown(event);
+    if(!isGamePaused() || event.keyCode === 73) handleKeyDown(event);
   },
     ANIMATION_HOLD_SPEED,
     { maxWait: ANIMATION_HOLD_SPEED, leading: true, trailing: false }
@@ -118,12 +116,6 @@ const Controls = ({ isGamePaused, attackMonster, movePlayer, toggleInventory }) 
     };
   }, []);
 
-  function handleInventoryVisibilityKeyDown(event) {
-    event.preventDefault();
-    // open inventory with "I" key
-    if(event.keyCode === 73) return toggleInventory();
-  }
-
   function handleKeyDown(event) {
     event.preventDefault();
     // move with 'WASD' or Arrow keys
@@ -144,6 +136,9 @@ const Controls = ({ isGamePaused, attackMonster, movePlayer, toggleInventory }) 
       case 32:
         // attack with enter or space key
         return attackMonster();
+      case 73:
+        // open inventory with "I" key
+        return toggleInventory();
       default:
         // console.log('key not mapped: ', event.keyCode);
     }

--- a/src/features/player/controls.js
+++ b/src/features/player/controls.js
@@ -6,17 +6,21 @@ import _debounce     from 'lodash.debounce';
 import attackMonster       from './actions/attack-monster';
 import movePlayer          from './actions/move-player';
 import isGamePaused        from '../dialog-manager/actions/is-game-paused';
+import toggleInventory     from '../dialog-manager/actions/toggle-inventory';
 import { ANIMATION_SPEED } from '../../config/constants';
 
 const ANIMATION_HOLD_SPEED = ANIMATION_SPEED * 1.25;
 
 let intervalId = null;
 
-const Controls = ({ isGamePaused, attackMonster, movePlayer }) => {
+const Controls = ({ isGamePaused, attackMonster, movePlayer, toggleInventory }) => {
 
   const _handleKeyDown = _debounce(event => {
     // if the game is not paused by dialogs
     if(!isGamePaused()) handleKeyDown(event);
+
+    // toggle inventory visibility regardless of whether it is paused by dialogs
+    handleInventoryVisibilityKeyDown(event);
   },
     ANIMATION_HOLD_SPEED,
     { maxWait: ANIMATION_HOLD_SPEED, leading: true, trailing: false }
@@ -114,6 +118,12 @@ const Controls = ({ isGamePaused, attackMonster, movePlayer }) => {
     };
   }, []);
 
+  function handleInventoryVisibilityKeyDown(event) {
+    event.preventDefault();
+    // open inventory with "I" key
+    if(event.keyCode === 73) return toggleInventory();
+  }
+
   function handleKeyDown(event) {
     event.preventDefault();
     // move with 'WASD' or Arrow keys
@@ -142,6 +152,6 @@ const Controls = ({ isGamePaused, attackMonster, movePlayer }) => {
   return null;
 };
 
-const actions = { attackMonster, movePlayer, isGamePaused };
+const actions = { attackMonster, movePlayer, toggleInventory, isGamePaused };
 
 export default connect(null, actions)(Controls);

--- a/src/features/snackbar/index.js
+++ b/src/features/snackbar/index.js
@@ -13,8 +13,6 @@ class Snackbar extends Component {
     this.state = {
       show: ''
     };
-
-    this.handleHideSnack = this.handleHideSnack.bind(this);
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -50,7 +48,7 @@ class Snackbar extends Component {
     }
   }
 
-  handleHideSnack() {
+  handleHideSnack = () => {
     this.setState({ show: '' });
   }
 

--- a/src/features/stats/index.js
+++ b/src/features/stats/index.js
@@ -13,8 +13,6 @@ class Stats extends Component {
     this.state = {
       statsBgColor: 'var(--dark-gray)'
     };
-
-    this.stopAnimation = this.stopAnimation.bind(this);
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -28,7 +26,7 @@ class Stats extends Component {
     }
   }
 
-  stopAnimation() {
+  stopAnimation = () => {
     this.setState({ statsBgColor: 'var(--dark-gray)' });
   }
 


### PR DESCRIPTION
All keybindings are now in one file. I checked out #60 verified that it basically did what I attempted to do a few days ago, but the issue remains: the inventory button is still listening for the `[Enter]` and `[Space]` keys. 

Unfortunately, I had no better idea at the moment other than to maintain the `handleKeyDown(event) {}` class method in `<Inventory />` to do an `event.preventDefault()`. Does anyone else have a more elegant solution?

P.S.: @Alaricus your inventory label button changes has been included.
