### PR TITLE
add cname file for gh pages

### DIFF
--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+react-rpg.com


### PR DESCRIPTION
prevents an issue where gh pages would keep losing track of the domain name, thus screwing up the hosting